### PR TITLE
Add install instructions for Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,22 @@ export SSH_AUTH_SOCK="/usr/local/var/run/yubikey-agent.sock"
 
 ### Linux
 
-`yubikey-agent` already works on Linux. A simple installation process is coming soon.
+For a manual installation, you'll need Go, the [`piv-go` dependencies](https://github.com/go-piv/piv-go#installation), and a `pinentry` program in PATH. A systemd unit is provided to launch yubikey-agent on login (tested on Ubuntu 20.04).
 
-For a manual installation, you'll need Go, the [`piv-go` dependencies](https://github.com/go-piv/piv-go#installation), a `pinentry` program in PATH, and a [systemd unit](https://github.com/FiloSottile/yubikey-agent/blob/f8091cc4a330cc5c5960b9f8f8fe31531e4a8f18/systemd.md) or similar. Packaging contributions are very welcome.
+```
+go get filippo.io/yubikey-agent
+go install filippo.io/yubikey-agent
+sudo cp $GOPATH/bin/yubikey-agent /usr/local/bin/
+sudo cp $GOPATH/src/filippo.io/yubikey-agent/linux/yubikey-agent-launch /usr/local/bin/
+sudo cp $GOPATH/src/filippo.io/yubikey-agent/linux/yubikey-agent.service /usr/lib/systemd/user/
+sudo ln -s ../yubikey-agent.service /usr/lib/systemd/user/graphical-session-pre.target.wants/yubikey-agent.service
+# Note: This disables ssh-agent so yubikey-agent-launch can reliably set
+# SSH_AUTH_SOCK. If you'd like to use both, just append use-yubikey-agent
+# to this file. You'll need to manually configure IdentityAgent (see below)
+sudo sed -i 's/use-ssh-agent/use-yubikey-agent/' /etc/X11/Xsession.options
+```
+
+Log out and log back in again.
 
 ### Windows
 

--- a/linux/yubikey-agent-launch
+++ b/linux/yubikey-agent-launch
@@ -1,0 +1,24 @@
+#!/bin/sh
+# helper script for launching yubikey-agent, used by systemd unit
+# adapted from the Ubuntu openssh-client package.
+set -e
+
+if [ ! -d "$XDG_RUNTIME_DIR" ]; then
+    echo 'This needs $XDG_RUNTIME_DIR to be set' >&2
+    exit 1
+fi
+
+if [ "$1" = start ]; then
+    if [ -z "$SSH_AUTH_SOCK" ] && grep -s -q '^use-yubikey-agent$' /etc/X11/Xsession.options; then
+        S="$XDG_RUNTIME_DIR/yubikey_agent"
+        dbus-update-activation-environment --verbose --systemd SSH_AUTH_SOCK=$S SSH_AGENT_LAUNCHER=yubikey-agent
+        exec yubikey-agent -l $S
+    fi
+elif [ "$1" = stop ]; then
+    if [ "$SSH_AGENT_LAUNCHER" = yubikey-agent ]; then
+        dbus-update-activation-environment --systemd  SSH_AUTH_SOCK=
+    fi
+else
+    echo "Unknown command $1" >&2
+    exit 1
+fi

--- a/linux/yubikey-agent-launch
+++ b/linux/yubikey-agent-launch
@@ -3,15 +3,15 @@
 # adapted from the Ubuntu openssh-client package.
 set -e
 
-if [ ! -d "$XDG_RUNTIME_DIR" ]; then
-    echo 'This needs $XDG_RUNTIME_DIR to be set' >&2
+if [ ! -d "$RUNTIME_DIRECTORY" ]; then
+    echo 'This needs $RUNTIME_DIRECTORY to be set' >&2
     exit 1
 fi
 
 if [ "$1" = start ]; then
     if [ -z "$SSH_AUTH_SOCK" ] && grep -s -q '^use-yubikey-agent$' /etc/X11/Xsession.options; then
-        S="$XDG_RUNTIME_DIR/yubikey_agent"
-        dbus-update-activation-environment --verbose --systemd SSH_AUTH_SOCK=$S SSH_AGENT_LAUNCHER=yubikey-agent
+        S="$RUNTIME_DIRECTORY/socket"
+        dbus-update-activation-environment --systemd SSH_AUTH_SOCK=$S SSH_AGENT_LAUNCHER=yubikey-agent
         exec yubikey-agent -l $S
     fi
 elif [ "$1" = stop ]; then

--- a/linux/yubikey-agent.service
+++ b/linux/yubikey-agent.service
@@ -4,8 +4,35 @@ Documentation=https://github.com/FiloSottile/yubikey-agent
 Before=graphical-session-pre.target
 ConditionPathExists=/etc/X11/Xsession.options
 Wants=dbus.socket
+Requires=pcscd.socket
 After=dbus.socket
 
 [Service]
 ExecStart=/usr/local/bin/yubikey-agent-launch start
 ExecStopPost=/usr/local/bin/yubikey-agent-launch stop
+
+ProtectSystem=strict
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+ProtectHostname=yes
+PrivateTmp=yes
+PrivateDevices=yes
+PrivateUsers=yes
+IPAddressDeny=any
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+CapabilityBoundingSet=
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+SystemCallErrorNumber=EPERM
+SystemCallArchitectures=native
+NoNewPrivileges=yes
+KeyringMode=private
+UMask=0177
+RuntimeDirectory=yubikey-agent

--- a/linux/yubikey-agent.service
+++ b/linux/yubikey-agent.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=yubikey-agent
+Documentation=https://github.com/FiloSottile/yubikey-agent
+Before=graphical-session-pre.target
+ConditionPathExists=/etc/X11/Xsession.options
+Wants=dbus.socket
+After=dbus.socket
+
+[Service]
+ExecStart=/usr/local/bin/yubikey-agent-launch start
+ExecStopPost=/usr/local/bin/yubikey-agent-launch stop


### PR DESCRIPTION
This provides a systemd unit that starts yubikey-agent at graphical
login and runs it as the logged-in user, paralleling how Ubuntu treats
ssh-agent. Not yet tested on other systemd-using distros.