### PR TITLE
Set the systemd WantedBy directive to default.target

### DIFF
--- a/systemd.md
+++ b/systemd.md
@@ -52,7 +52,7 @@ UMask=0177
 RuntimeDirectory=yubikey-agent
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 ```
 
 Refresh systemd, make sure that the PC/SC daemon is available, and start the yubikey-agent.


### PR DESCRIPTION
With the current choice of multi-user.target the agent do not start when
the user boots with a local GUI login.

Closes #39