### PR TITLE
Ignore cards which aren't YubiKeys

### DIFF
--- a/main.go
+++ b/main.go
@@ -152,22 +152,23 @@ func healthy(yk *piv.YubiKey) bool {
 }
 
 func (a *Agent) ensureYK() error {
-	if a.yk == nil || !healthy(a.yk) {
-		if a.yk != nil {
-			log.Println("Reconnecting to the YubiKey...")
-			a.yk.Close()
-		} else {
-			log.Println("Connecting to the YubiKey...")
-		}
-		var err error
-		if a.yk, err = getYK(); err != nil {
-			return err
-		}
-		// Cache the serial number locally because requesting it on older firmwares
-		// requires switching application, which drops the PIN cache.
-		if a.serial, err = a.yk.Serial(); err != nil {
-			return err
-		}
+	if a.yk != nil && healthy(a.yk) {
+		return nil
+	}
+	if a.yk != nil {
+		log.Println("Reconnecting to the YubiKey...")
+		a.yk.Close()
+	} else {
+		log.Println("Connecting to the YubiKey...")
+	}
+	var err error
+	if a.yk, err = getYK(); err != nil {
+		return err
+	}
+	// Cache the serial number locally because requesting it on older firmwares
+	// requires switching application, which drops the PIN cache.
+	if a.serial, err = a.yk.Serial(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/setup.go
+++ b/setup.go
@@ -43,23 +43,22 @@ func init() {
 	Version = "(unknown version)"
 }
 
-func connectForSetup() *piv.YubiKey {
+func getYK() (*piv.YubiKey, error) {
 	cards, err := piv.Cards()
 	if err != nil {
-		log.Fatalln("Failed to enumerate tokens:", err)
+		return nil, fmt.Errorf("failed to enumerate tokens: %w", err)
 	}
 	// TODO: support multiple YubiKeys.
 	for _, card := range cards {
 		if strings.Contains(strings.ToLower(card), "yubikey") {
 			yk, err := piv.Open(card)
 			if err != nil {
-				log.Fatalln("Failed to connect to the YubiKey:", err)
+				return nil, fmt.Errorf("failed to connect to the YubiKey: %w", err)
 			}
-			return yk
+			return yk, nil
 		}
 	}
-	log.Fatalln("No YubiKeys detected!")
-	return nil
+	return nil, fmt.Errorf("no YubiKeys detected")
 }
 
 func runReset(yk *piv.YubiKey) {

--- a/setup.go
+++ b/setup.go
@@ -19,6 +19,7 @@ import (
 	"math/big"
 	"os"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/go-piv/piv-go/piv"
@@ -47,15 +48,18 @@ func connectForSetup() *piv.YubiKey {
 	if err != nil {
 		log.Fatalln("Failed to enumerate tokens:", err)
 	}
-	if len(cards) == 0 {
-		log.Fatalln("No YubiKeys detected!")
-	}
 	// TODO: support multiple YubiKeys.
-	yk, err := piv.Open(cards[0])
-	if err != nil {
-		log.Fatalln("Failed to connect to the YubiKey:", err)
+	for _, card := range cards {
+		if strings.Contains(strings.ToLower(card), "yubikey") {
+			yk, err := piv.Open(card)
+			if err != nil {
+				log.Fatalln("Failed to connect to the YubiKey:", err)
+			}
+			return yk
+		}
 	}
-	return yk
+	log.Fatalln("No YubiKeys detected!")
+	return nil
 }
 
 func runReset(yk *piv.YubiKey) {


### PR DESCRIPTION
I've got another smart card reader built into my laptop that `yubikey-agent` tries to use and fails.

This fixes the issue.