### PR TITLE
Add option to set touch policy to "cache"

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -65,7 +65,7 @@ func runReset(yk *piv.YubiKey) {
 	}
 }
 
-func runSetup(yk *piv.YubiKey) {
+func runSetup(yk *piv.YubiKey, touchPolicy piv.TouchPolicy) {
 	if _, err := yk.Certificate(piv.SlotAuthentication); err == nil {
 		log.Println("‼️  This YubiKey looks already setup")
 		log.Println("")
@@ -139,7 +139,7 @@ func runSetup(yk *piv.YubiKey) {
 	pub, err := yk.GenerateKey(key, piv.SlotAuthentication, piv.Key{
 		Algorithm:   piv.AlgorithmEC256,
 		PINPolicy:   piv.PINPolicyOnce,
-		TouchPolicy: piv.TouchPolicyAlways,
+		TouchPolicy: touchPolicy,
 	})
 	if err != nil {
 		log.Fatalln("Failed to generate key:", err)


### PR DESCRIPTION
This adds an optional setup flag that allows the touch policy to be set. ~to "cache for 15 seconds" instead of "always".~

~I've tried to add this feature in the least obtrusive way possible, but the command line is getting a little complex for the plain old `flag` package. Would there be any interest in using a CLI library in `yubikey-agent`?~

Closes: #52 