### PR TITLE
Load public keys from all slots on the Yubikey to support different touch policies

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -15,23 +15,15 @@ var slotBenchmarkCases = []struct {
 	slots []piv.Slot
 }{
 	{
-		name: "1 slot",
+		name: "1 slot 9a",
 		slots: []piv.Slot{
 			piv.SlotAuthentication,
-		},
-	},
-
-	{
-		name: "2 slots both exist",
-		slots: []piv.Slot{
-			piv.SlotAuthentication,
-			piv.SlotKeyManagement,
 		},
 	},
 
 	// This assumes there are certificates on slots 9A and 9D only.
 	{
-		name: "2 slots 1 exist",
+		name: "2 slots 9a 9e",
 		slots: []piv.Slot{
 			piv.SlotAuthentication,
 			piv.SlotCardAuthentication,
@@ -39,7 +31,15 @@ var slotBenchmarkCases = []struct {
 	},
 
 	{
-		name: "4 slots",
+		name: "2 slots 9a 9d",
+		slots: []piv.Slot{
+			piv.SlotAuthentication,
+			piv.SlotKeyManagement,
+		},
+	},
+
+	{
+		name: "4 slots 9a 9e 9d 9c",
 		slots: []piv.Slot{
 			piv.SlotAuthentication,
 			piv.SlotCardAuthentication,

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/go-piv/piv-go/piv"
+)
+
+func setSlots(newSlots []piv.Slot) {
+	slots = newSlots
+}
+
+var slotBenchmarkCases = []struct {
+	name  string
+	slots []piv.Slot
+}{
+	{
+		name: "1 slot",
+		slots: []piv.Slot{
+			piv.SlotAuthentication,
+		},
+	},
+
+	{
+		name: "2 slots both exist",
+		slots: []piv.Slot{
+			piv.SlotAuthentication,
+			piv.SlotKeyManagement,
+		},
+	},
+
+	// This assumes there are certificates on slots 9A and 9D only.
+	{
+		name: "2 slots 1 exist",
+		slots: []piv.Slot{
+			piv.SlotAuthentication,
+			piv.SlotCardAuthentication,
+		},
+	},
+
+	{
+		name: "4 slots",
+		slots: []piv.Slot{
+			piv.SlotAuthentication,
+			piv.SlotCardAuthentication,
+			piv.SlotKeyManagement,
+			piv.SlotSignature,
+		},
+	},
+}
+
+func BenchmarkList(b *testing.B) {
+	a := &Agent{}
+	b.Cleanup(func() {
+		a.Close()
+	})
+
+	for _, bc := range slotBenchmarkCases {
+		b.Run(bc.name, func(b *testing.B) {
+			setSlots(bc.slots)
+			for i := 0; i < b.N; i++ {
+				_, err := a.List()
+				if err != nil {
+					b.Error(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkSigners(b *testing.B) {
+	a := &Agent{}
+	b.Cleanup(func() {
+		a.Close()
+	})
+	if err := a.ensureYK(); err != nil {
+		b.Errorf("could not reach YubiKey: %w", err)
+	}
+
+	for _, bc := range slotBenchmarkCases {
+		b.Run(bc.name, func(b *testing.B) {
+			setSlots(bc.slots)
+			for i := 0; i < b.N; i++ {
+				_, err := a.signers()
+				if err != nil {
+					b.Error(err)
+				}
+			}
+		})
+	}
+}

--- a/contrib/add-second-key/main.go
+++ b/contrib/add-second-key/main.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"log"
+	"math/big"
+	"os"
+	"time"
+
+	"github.com/go-piv/piv-go/piv"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+var Version = "devel"
+
+func connectForSetup() *piv.YubiKey {
+	cards, err := piv.Cards()
+	if err != nil {
+		log.Fatalln("Failed to enumerate tokens:", err)
+	}
+	if len(cards) == 0 {
+		log.Fatalln("No YubiKeys detected!")
+	}
+	// TODO: support multiple YubiKeys.
+	yk, err := piv.Open(cards[0])
+	if err != nil {
+		log.Fatalln("Failed to connect to the YubiKey:", err)
+	}
+	return yk
+}
+
+func main() {
+	yk := connectForSetup()
+	fmt.Print("PIN: ")
+	pin, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Print("\n")
+	if err != nil {
+		log.Fatalln("Failed to read PIN:", err)
+	}
+	if len(pin) == 0 || len(pin) > 8 {
+		log.Fatalln("The PIN needs to be 1-8 characters.")
+	}
+	m, err := yk.Metadata(string(pin))
+	if err != nil {
+		log.Fatal("Failed to get metadata from Yubikey")
+	}
+	if m.ManagementKey == nil {
+		log.Fatal("Failed to get management key from metadata")
+	}
+	key := *m.ManagementKey
+
+	// fmt.Printf("Management key is: %x\n", key)
+	slot := piv.SlotKeyManagement
+	fmt.Printf("Generating private key on slot %x\n", slot.Key)
+	pub, err := yk.GenerateKey(key, slot, piv.Key{
+		Algorithm:   piv.AlgorithmEC256,
+		PINPolicy:   piv.PINPolicyOnce,
+		TouchPolicy: piv.TouchPolicyNever,
+	})
+	if err != nil {
+		log.Fatalln("Failed to generate key:", err)
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		log.Fatalln("Failed to generate parent key:", err)
+	}
+	parent := &x509.Certificate{
+		Subject: pkix.Name{
+			Organization:       []string{"yubikey-agent"},
+			OrganizationalUnit: []string{Version},
+		},
+		PublicKey: priv.Public(),
+	}
+	template := &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "SSH key with NO TOUCH REQUIRED",
+		},
+		NotAfter:     time.Now().AddDate(42, 0, 0),
+		NotBefore:    time.Now(),
+		SerialNumber: randomSerialNumber(),
+		KeyUsage:     x509.KeyUsageKeyAgreement | x509.KeyUsageDigitalSignature,
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, parent, pub, priv)
+	if err != nil {
+		log.Fatalln("Failed to generate certificate:", err)
+	}
+	cert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		log.Fatalln("Failed to parse certificate:", err)
+	}
+	if err := yk.SetCertificate(key, slot, cert); err != nil {
+		log.Fatalln("Failed to store certificate:", err)
+	}
+
+	sshKey, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		log.Fatalln("Failed to generate public key:", err)
+	}
+
+	fmt.Println("")
+	fmt.Printf("✅ Done! No-touch key stored to slot %x\n", slot.Key)
+	fmt.Println("")
+	fmt.Println("🔑 Here's your new shiny SSH public key:")
+	os.Stdout.Write(ssh.MarshalAuthorizedKey(sshKey))
+
+}
+
+func randomSerialNumber() *big.Int {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		log.Fatalln("Failed to generate serial number:", err)
+	}
+	return serialNumber
+}

--- a/main.go
+++ b/main.go
@@ -229,21 +229,28 @@ func (a *Agent) List() ([]*agent.Key, error) {
 		return nil, fmt.Errorf("could not reach YubiKey: %w", err)
 	}
 
-	pk, err := getPublicKey(a.yk, piv.SlotAuthentication)
-	if err != nil {
-		return nil, err
+	var keys []*agent.Key
+	for _, slot := range slots {
+		var pk ssh.PublicKey
+		var err error
+		pk, err = getPublicKey(a.yk, slot)
+		if err != nil {
+			continue
+		}
+		k := &agent.Key{
+			Format:  pk.Type(),
+			Blob:    pk.Marshal(),
+			Comment: fmt.Sprintf("YubiKey #%d PIV Slot %x", a.serial, slot.Key),
+		}
+		keys = append(keys, k)
 	}
-	return []*agent.Key{{
-		Format:  pk.Type(),
-		Blob:    pk.Marshal(),
-		Comment: fmt.Sprintf("YubiKey #%d PIV Slot 9a", a.serial),
-	}}, nil
+	return keys, nil
 }
 
 func getPublicKey(yk *piv.YubiKey, slot piv.Slot) (ssh.PublicKey, error) {
 	cert, err := yk.Certificate(slot)
 	if err != nil {
-		return nil, fmt.Errorf("could not get public key: %w", err)
+		return nil, fmt.Errorf("could not get public key from slot %x: %w", slot.Key, err)
 	}
 	switch cert.PublicKey.(type) {
 	case *ecdsa.PublicKey:
@@ -268,24 +275,35 @@ func (a *Agent) Signers() ([]ssh.Signer, error) {
 	return a.signers()
 }
 
+var slots = []piv.Slot{
+	piv.SlotAuthentication,
+	piv.SlotCardAuthentication,
+	piv.SlotKeyManagement,
+	piv.SlotSignature,
+}
+
 func (a *Agent) signers() ([]ssh.Signer, error) {
-	pk, err := getPublicKey(a.yk, piv.SlotAuthentication)
-	if err != nil {
-		return nil, err
+	var signers []ssh.Signer
+	for _, slot := range slots {
+		pk, err := getPublicKey(a.yk, slot)
+		if err != nil {
+			continue
+		}
+		priv, err := a.yk.PrivateKey(
+			slot,
+			pk.(ssh.CryptoPublicKey).CryptoPublicKey(),
+			piv.KeyAuth{PINPrompt: a.getPIN},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prepare private key: %w", err)
+		}
+		s, err := ssh.NewSignerFromKey(priv)
+		if err != nil {
+			return nil, fmt.Errorf("failed to prepare signer: %w", err)
+		}
+		signers = append(signers, s)
 	}
-	priv, err := a.yk.PrivateKey(
-		piv.SlotAuthentication,
-		pk.(ssh.CryptoPublicKey).CryptoPublicKey(),
-		piv.KeyAuth{PINPrompt: a.getPIN},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to prepare private key: %w", err)
-	}
-	s, err := ssh.NewSignerFromKey(priv)
-	if err != nil {
-		return nil, fmt.Errorf("failed to prepare signer: %w", err)
-	}
-	return []ssh.Signer{s}, nil
+	return signers, nil
 }
 
 func (a *Agent) Sign(key ssh.PublicKey, data []byte) (*ssh.Signature, error) {


### PR DESCRIPTION
For #22.

To support different touch policies with one Yubikey, load keys from the 4 PIV slots on Yubikey that the Yubikey Manager shows.

I think the change in main.go is reasonable. I don't think the code to add the second key necessarily needs to be in this project. The benchmark will need more love if we want to include it, e.g. how to initialize the Yubikey under test?

Previously I was concerned about potential slowdown but here I created a non-destructive benchmark to see performance differences of the functions I modified. I don't want to delete my current second key so I can't easily run the benchmark with just the first certificate existing.

Below my benchmark with Yubikey 5 NFC when I have certificates in slots 9a and 9d. You can note that adding the second non-existing slot has little impact (2_slots_9a_9e), but when the certificate exists (2_slots_9a_9d), there is significant slowdown. Loading all 4 slots (4_slots_9a_9e_9d_9c) has some difference to 2_slots_9a_9d, but not huge.

I would think adding a second slot by default would be acceptable, and all slots not too bad. Question then is: can we make loading all slots the default (or cache slots on first use?) or does this need to be a configurable preference?

```
[joneskoo@grant yubikey-agent]$ go test -bench .
2020/09/16 01:06:01 Connecting to the YubiKey...
goos: darwin
goarch: amd64
pkg: filippo.io/yubikey-agent
BenchmarkList/1_slot_9a-8                    158           7430363 ns/op
BenchmarkList/2_slots_9a_9e-8                151           7884287 ns/op
BenchmarkList/2_slots_9a_9d-8                128           9366908 ns/op
BenchmarkList/4_slots_9a_9e_9d_9c-8                  100          11967745 ns/op
2020/09/16 01:06:08 Received SIGHUP, dropping YubiKey transaction...
2020/09/16 01:06:08 Connecting to the YubiKey...
BenchmarkSigners/1_slot_9a-8                           8         139677175 ns/op
BenchmarkSigners/2_slots_9a_9e-8                       8         141074461 ns/op
BenchmarkSigners/2_slots_9a_9d-8                       4         280662836 ns/op
BenchmarkSigners/4_slots_9a_9e_9d_9c-8                 4         284958780 ns/op
2020/09/16 01:06:15 Received SIGHUP, dropping YubiKey transaction...
PASS
ok      filippo.io/yubikey-agent        14.164s
```

This is rebasing and updating #27.