### PR TITLE
Allow generating the private key on the computer

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ In practice, any PIV token with an RSA or ECDSA P-256 key and certificate in the
 
 `yubikey-agent -setup` generates a random Management Key and [stores it in PIN-protected metadata](https://pkg.go.dev/github.com/go-piv/piv-go/piv?tab=doc#YubiKey.SetMetadata).
 
+By default `yubikey-agent -setup` generates the private key on the hardware token (a YubiKey device). There's a `--generate-key-on-computer-insecurely` switch that makes it generate the private key on the computer running `yubikey-agent`, import the key to the YubiKey device and print the private key on the screen. This allows creating a backup of the private key in case you lose or damage your YubiKey. This option **should only be used if you know what you're doing**, because generating a key this way exposes it to being exfiltrated or manipulated when importing to the device which makes you less secure.
+
 ### Alternatives
 
 #### Native FIDO2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module filippo.io/yubikey-agent
 go 1.14
 
 require (
-	github.com/go-piv/piv-go v1.5.1-0.20200523071327-a3e5767e8b72
+	github.com/go-piv/piv-go v1.7.0
 	github.com/gopasspw/gopass v1.10.1
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
 )

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/go-piv/piv-go v1.5.1-0.20200523071327-a3e5767e8b72 h1:ks5VMs/eHR427mPrB3+v7DtN+VO2Ndp/csIc0ZADApE=
-github.com/go-piv/piv-go v1.5.1-0.20200523071327-a3e5767e8b72/go.mod h1:ON2WvQncm7dIkCQ7kYJs+nc3V4jHGfrrJnSF8HKy7Gk=
+github.com/go-piv/piv-go v1.7.0 h1:rfjdFdASfGV5KLJhSjgpGJ5lzVZVtRWn8ovy/H9HQ/U=
+github.com/go-piv/piv-go v1.7.0/go.mod h1:ON2WvQncm7dIkCQ7kYJs+nc3V4jHGfrrJnSF8HKy7Gk=
 github.com/godbus/dbus v0.0.0-20190623212516-8a1682060722 h1:NNKZiuNXd6lpZRyoFM/uhssj5W9Ps1DbhGHxT49Pm9I=
 github.com/godbus/dbus v0.0.0-20190623212516-8a1682060722/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/gokyle/twofactor v1.0.1 h1:uRhvx0S4Hb82RPIDALnf7QxbmPL49LyyaCkJDpWx+Ek=


### PR DESCRIPTION
This is to allow creating backups of the private key in case the YubiKey
gets lost or damaged. The word "insecurely" is appended to the name of
the switch and a long warning produced in order to make people who don't
know what they're doing turn away and stop what they're doing.

This is possible since piv-go 1.7.0[1] so I allowed myself to bump the
version of this requirement.

While I do have several doubts about approaching this (see below) I believe this
is a useful thing to have. What I'm unsure about is:

* The code quality (I'm not writing Go day to day)
* I may have done something stupid cryptography-wise here, I'm not a cryptographer or a security specialist
* How to warn properly so that people not knowing what they're doing don't use the new switch – I think I've done a decent job here
* Should this be mentioned in the readme? I mentioned it for documentation purposes
* Should this be mentioned in the `--help` output? The existing `--really-delete-all-piv-keys` flag is not there so I skipped it
* Should there be advice that when this option is used it's better to do it on a clean system, on a trusted machine, offline and airgapped ideally, and any potential backups should be encrypted and stored securely?
* Should the main agent daemon always handle keys that fail attestation (caused by generating on the computer instead of on the device) like I added here or maybe make this configurable with a switch?

Closes GH-65.

[1] https://github.com/go-piv/piv-go/pull/83#issuecomment-740707527