### PR TITLE
Update README.md to use HOMEBREW_PREFIX for mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ yubikey-agent -setup # generate a new key on the YubiKey
 Then add the following line to your `~/.zshrc` and restart the shell.
 
 ```
-export SSH_AUTH_SOCK="/usr/local/var/run/yubikey-agent.sock"
+export SSH_AUTH_SOCK="$HOMEBREW_PREFIX/var/run/yubikey-agent.sock"
 ```
 
 ### Linux

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ yubikey-agent -setup # generate a new key on the YubiKey
 Then add the following line to your `~/.zshrc` and restart the shell.
 
 ```
-export SSH_AUTH_SOCK="$HOMEBREW_PREFIX/var/run/yubikey-agent.sock"
+export SSH_AUTH_SOCK="$(brew --prefix)/var/run/yubikey-agent.sock"
 ```
 
 ### Linux


### PR DESCRIPTION
Instead of using the hardcoded path /usr/local as a prefix for homebrew, the value $HOMEBREW_PREFIX can be used. Especially since installing Homebrew seems to put all the files in /opt/homebrew now.