### PR TITLE
signers: allow all card slots and imported keys, sign confirmation and card select by serial

### DIFF
--- a/prompt_pinentry.go
+++ b/prompt_pinentry.go
@@ -42,3 +42,16 @@ func getPIN(serial uint32, retries int) (string, error) {
 	pin, err := p.GetPin()
 	return string(pin), err
 }
+
+func userConfirm() error {
+	p, err := pinentry.New()
+	if err != nil {
+		return fmt.Errorf("failed to start %q: %w", pinentry.GetBinary(), err)
+	}
+	defer p.Close()
+	p.Set("title", "yubikey-agent confirm signing")
+	p.Set("prompt", "Please confirm yubikey operation")
+
+	_, err = p.GetPin()
+	return err
+}


### PR DESCRIPTION
- creates a cli configuration flag (--slot authentication) to be
  able to specify which slots should be enabled
- also allow specifying a pin policy (--slot signature,always) to allow
  for imported keys. Since these do not have a valid attestation which
  would be used to determine the pin policy otherwise we have to set it.
- allow selecting a specific yubikey by its serial number. otherwise try all cards to find a valid one (my laptop sometimes has its internal smartcard reader in the cards list which will fail to "Open()" without a card though
- add "ssh-add -c" equivalent key use confirmation. when a pin cache is in use it is good practice to know when the card/key is actually used for signing

to enable all slots with imported keys for a typical PIV config you could use:
yubikey-agent -l agent.sock --slot authentication,once --slot signature,always --slot keymanagement,once

The default without any parameters matches the current config (only Authentication and no configured pin policy).

This change makes yubikey-agent immediately usable with previously generated / imported keys (which i think a lot of people at least in the corporate world have).

Similar to #57 but focused on usage of all imported keys.