### PR TITLE
update dependency of pinentry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
-module filippo.io/yubikey-agent
+module github.com/gador/yubikey-agent
 
 go 1.17
 
 require (
 	github.com/go-piv/piv-go v1.9.0
-	github.com/gopasspw/pinentry v0.0.2
+	github.com/gopasspw/pinentry v0.0.3-0.20211111080829-f73e4f2a12d3
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
-	golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c // indirect
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf
 )
+
+require golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gador/yubikey-agent
+module filippo.io/yubikey-agent
 
 go 1.17
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/go-piv/piv-go v1.9.0 h1:P6j2gjfP7zO7T3nCk/jwCgsvFRwB8shEqAJ4q85jgXc=
 github.com/go-piv/piv-go v1.9.0/go.mod h1:NZ2zmjVkfFaL/CF8cVQ/pXdXtuj110zEKGdJM6fJZZM=
-github.com/gopasspw/pinentry v0.0.2 h1:6OmkoTYMU05PmAJSIZSRjjhiQX15AstdgNa2KimH5XA=
-github.com/gopasspw/pinentry v0.0.2/go.mod h1:lR1WuNI96rXXBCgM601Ima3acnX3ZSPthIAuG6lHa68=
+github.com/gopasspw/pinentry v0.0.3-0.20211111080829-f73e4f2a12d3 h1:+zdLxUTwYgq/TstQIB0OyGkJBKARyRGqiuJ7wkkQC3M=
+github.com/gopasspw/pinentry v0.0.3-0.20211111080829-f73e4f2a12d3/go.mod h1:lR1WuNI96rXXBCgM601Ima3acnX3ZSPthIAuG6lHa68=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8LoP3mpSgBW8BUoxtEdbXg=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=


### PR DESCRIPTION
This upstream fix will check whether the path of pinentry acutally
exists. Otherwise will default to return "pinentry".

Since #82 and the update of pinentry, it uses gpgconf to discover the pinentry binary path. This doesn't always work. So pinentry got a fix to check whether the path actually exists. 
This PR updates the dependency to point to the new version.

Fixes https://github.com/NixOS/nixpkgs/issues/145392. 