### PR TITLE
Support `ssh-add -D` to close Yubikey transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,8 @@ Host *
 
 `yubikey-agent` takes a persistent transaction so the YubiKey will cache the PIN after first use. Unfortunately, this makes the YubiKey PIV and PGP applets unavailable to any other applications, like `gpg-agent` and Yubikey Manager. Our upstream [is investigating solutions to this annoyance](https://github.com/go-piv/piv-go/issues/47).
 
-If you need `yubikey-agent` to release its lock on the YubiKey, send it a hangup signal OR use `ssh-add`'s "delete all identities" flag. Likewise, you might have to kill `gpg-agent` after use for it to release its own lock.
+If you need `yubikey-agent` to release its lock on the YubiKey, send it a hangup signal or use `ssh-add`'s "delete all identities" flag. Likewise, you might have to kill `gpg-agent` after use for it to release its own lock.
 
-```
-killall -HUP yubikey-agent
-```
-OR
 ```
 ssh-add -D
 ```

--- a/README.md
+++ b/README.md
@@ -106,10 +106,14 @@ Host *
 
 `yubikey-agent` takes a persistent transaction so the YubiKey will cache the PIN after first use. Unfortunately, this makes the YubiKey PIV and PGP applets unavailable to any other applications, like `gpg-agent` and Yubikey Manager. Our upstream [is investigating solutions to this annoyance](https://github.com/go-piv/piv-go/issues/47).
 
-If you need `yubikey-agent` to release its lock on the YubiKey, send it a hangup signal. Likewise, you might have to kill `gpg-agent` after use for it to release its own lock.
+If you need `yubikey-agent` to release its lock on the YubiKey, send it a hangup signal OR use `ssh-add`'s "delete all identities" flag. Likewise, you might have to kill `gpg-agent` after use for it to release its own lock.
 
 ```
 killall -HUP yubikey-agent
+```
+OR
+```
+ssh-add -D
 ```
 
 This does not affect the FIDO2 functionality.

--- a/main.go
+++ b/main.go
@@ -183,7 +183,7 @@ func (a *Agent) Close() error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.yk != nil {
-		log.Println("Received SIGHUP, dropping YubiKey transaction...")
+		log.Println("Received HUP, dropping YubiKey transaction...")
 		err := a.yk.Close()
 		a.yk = nil
 		return err
@@ -336,7 +336,7 @@ func (a *Agent) Remove(key ssh.PublicKey) error {
 	return ErrOperationUnsupported
 }
 func (a *Agent) RemoveAll() error {
-	return ErrOperationUnsupported
+	return a.Close()
 }
 func (a *Agent) Lock(passphrase []byte) error {
 	return ErrOperationUnsupported


### PR DESCRIPTION
Convenience for `yubikey-agent` to drop the transaction via `ssh-add -D`, in addition to `SIGHUP`.

Fixes #109