### PR TITLE
Ignore unready cards

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -43,15 +43,7 @@ func init() {
 }
 
 func connectForSetup() *piv.YubiKey {
-	cards, err := piv.Cards()
-	if err != nil {
-		log.Fatalln("Failed to enumerate tokens:", err)
-	}
-	if len(cards) == 0 {
-		log.Fatalln("No YubiKeys detected!")
-	}
-	// TODO: support multiple YubiKeys.
-	yk, err := piv.Open(cards[0])
+	yk, err := openYK()
 	if err != nil {
 		log.Fatalln("Failed to connect to the YubiKey:", err)
 	}


### PR DESCRIPTION
If other cards, e.g. due to internal card readers, are present, they are probably preferred and the YubiKey can not be used. Ignore unready cards and use the first available one.

Internal card readers are often present but seldom used. But they probably show up, at least that's the case on my system, before the external YubiKey and hence prevent its usage for yubikey-agent. When using the first ready card chances are much higher that it's actually the intended YubiKey. 