### PR TITLE
expire notification after five seconds in Linux

### DIFF
--- a/main.go
+++ b/main.go
@@ -346,7 +346,7 @@ func showNotification(message string) {
 		appleScript := `display notification "%s" with title "yubikey-agent"`
 		exec.Command("osascript", "-e", fmt.Sprintf(appleScript, message)).Run()
 	case "linux":
-		exec.Command("notify-send", "-i", "dialog-password", "yubikey-agent", message).Run()
+		exec.Command("notify-send", "-i", "dialog-password", "--expire-time=5000", "yubikey-agent", message).Run()
 	}
 }
 


### PR DESCRIPTION
otherwise the notification stays forever which is kind of annoying in DEs that store it indefinitely (like gnome) 

a better approach would be to remove the notification after it's been pressed, but notify-send doesn't allow that afaik (using a notification library would)