### PR TITLE
Change touch policy from always to cached

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -140,7 +140,7 @@ func runSetup(yk *piv.YubiKey) {
 	pub, err := yk.GenerateKey(key, piv.SlotAuthentication, piv.Key{
 		Algorithm:   piv.AlgorithmEC256,
 		PINPolicy:   piv.PINPolicyOnce,
-		TouchPolicy: piv.TouchPolicyAlways,
+		TouchPolicy: piv.TouchPolicyCached,
 	})
 	if err != nil {
 		log.Fatalln("Failed to generate key:", err)


### PR DESCRIPTION
This will change the key that's generated when running `yubikey-agent -setup` to a key with a touch policy of "cached". This will mean that "a touch is not needed if the YubiKey had been touched in the last 15 seconds, otherwise a touch is needed"

If changing this default touch policy isn't desired, no problem, feel free to close this PR out unmerged.

I did build from this and use it and it produced a key with a "cached" touch policy as expected.

Fixes #146