### PR TITLE
Add support for Ed25519 keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module filippo.io/yubikey-agent
 go 1.19
 
 require (
-	github.com/go-piv/piv-go v1.10.0
+	github.com/go-piv/piv-go/v2 v2.4.0
 	github.com/twpayne/go-pinentry-minimal v0.0.0-20220113210447-2a5dc4396c2a
 	golang.org/x/crypto v0.4.0
 	golang.org/x/term v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-piv/piv-go v1.10.0 h1:P1Y1VjBI5DnXW0+YkKmTuh5opWnMIrKriUaIOblee9Q=
-github.com/go-piv/piv-go v1.10.0/go.mod h1:NZ2zmjVkfFaL/CF8cVQ/pXdXtuj110zEKGdJM6fJZZM=
+github.com/go-piv/piv-go/v2 v2.4.0 h1:xamQ/fR4MJiw/Ndbk6yi7MVwhjrwlnDAPuaH9zcGb+I=
+github.com/go-piv/piv-go/v2 v2.4.0/go.mod h1:ShZi74nnrWNQEdWzRUd/3cSig3uNOcEZp+EWl0oewnI=
 github.com/twpayne/go-pinentry-minimal v0.0.0-20220113210447-2a5dc4396c2a h1:a1bRrtgkiv0tytmDVXU5Dqse/WOTws7JvsY2WxPMZ6M=
 github.com/twpayne/go-pinentry-minimal v0.0.0-20220113210447-2a5dc4396c2a/go.mod h1:ARJJXqNuaxVS84jX6ST52hQh0TtuQZWABhTe95a6BI4=
 golang.org/x/crypto v0.4.0 h1:UVQgzMY87xqpKNgb+kDsll2Igd33HszWHFLmpaRMq/8=

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
 	"errors"
@@ -28,7 +29,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/go-piv/piv-go/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/terminal"
@@ -249,6 +250,7 @@ func getPublicKey(yk *piv.YubiKey, slot piv.Slot) (ssh.PublicKey, error) {
 	}
 	switch cert.PublicKey.(type) {
 	case *ecdsa.PublicKey:
+	case ed25519.PublicKey:
 	case *rsa.PublicKey:
 	default:
 		return nil, fmt.Errorf("unexpected public key type: %T", cert.PublicKey)


### PR DESCRIPTION
This is basically the same as https://github.com/FiloSottile/yubikey-agent/pull/26 but implements the automatic algo selection by checking the firmware version as you mentioned in the other PR.

Yubikeys officially added support for Ed25519 keys in firmware version 5.7.0. Upstream piv-go added support for it in https://github.com/go-piv/piv-go/pull/157 (released in `v2.2.0`).

Note that Yubikey firmware 5.4.0 (technically 5.4.2 but I used the same version check as piv-go, see [this comment](https://github.com/go-piv/piv-go/pull/149#discussion_r1673855700)) added support for AES management keys so I also used the same firmware version detection method to upgrade the management key to AES256.

Tested locally on macOS Sequoia with Yubikey firmware 5.7.1