### PR TITLE
Fail fast on errors in `Accept`

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,14 +103,6 @@ func runAgent(socketPath string) {
 	for {
 		c, err := l.Accept()
 		if err != nil {
-			type temporary interface {
-				Temporary() bool
-			}
-			if err, ok := err.(temporary); ok && err.Temporary() {
-				log.Println("Temporary Accept error, sleeping 1s:", err)
-				time.Sleep(1 * time.Second)
-				continue
-			}
 			log.Fatalln("Failed to accept connections:", err)
 		}
 		go a.serveConn(c)


### PR DESCRIPTION
.. as it could loop infinitely, e.g. in absence of the YubiKey device in prevents `ssh` from using keys in `~/.ssh`

Fixes https://github.com/FiloSottile/yubikey-agent/issues/159